### PR TITLE
fix: update default branch in release config to 'main'

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,7 @@
 {
   "repositoryUrl": "https://github.com/vladdoster/neovim-configuration",
   "branches": [
-    "master"
+    "main"
   ],
   "plugins": [
     "@semantic-release/commit-analyzer",


### PR DESCRIPTION
* [`.releaserc.json`](diffhunk://#diff-e774e90e159e39c0a392fffa584ea8520508a9a0c10468d0bd685800e28a42f5L4-R4): Changed the primary branch from `master` to `main` to match the current repository setup.